### PR TITLE
specify Pete as the receiver of build errors notifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,6 @@ before_script:
   - sh -e /etc/init.d/xvfb start
 after_script:
   - ./node_modules/.bin/coveralls < coverage/PhantomJS*/lcov.info
+notifications:
+  email:
+    - pete.haughie@sourcefabric.org


### PR DESCRIPTION
@Flowdeeps i think that this is the right way to specify mail recipients. I will set Martin as the maintainer of the `citizendesk-interface` part
